### PR TITLE
Added URLs to the banned repo list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.xlsx
+banned-urls.txt
 exams

--- a/banned.md
+++ b/banned.md
@@ -1,86 +1,85 @@
-| Project | Year |
-|------- | ---- |
-| AngularDart    | 2015 |
-| Arduino    | 2017 |
-| Atom   | 2016 |
-| BigBlueButton  | 2016 |
-| Bootstrap  | 2016 |
-| Cartographer | 2018 |
-| CKAN   | 2016 |
-| CodeCombat     | 2016 |
-| D3.js  | 2016 |
-| Diaspora   | 2015 |
-| Docker     | 2015 |
-| Ember.js   | 2016 |
-| Gitlab     | 2016 |
-| Gradle     | 2017 |
-| Guava  | 2016 |
-| Habitica   | 2016 |
-| Homebrew | 2018 | 
-| JabRef     | 2017 |
-| Jekyll     | 2015 |
-| Joomla     | 2015 |
-| Junit5     | 2017 |
-| Jupyter Notebook   | 2017 |
-| Kafka  | 2017 |
-| Karma  | 2016 |
-| Keras | 2018 | 
-| Kibana     | 2017 |
-| Kodi   | 2015 |
-| Magento    | 2017 |
-| Mapbox GL  | 2017 |
-| MatplotLib     | 2017 |
-| Mockito    | 2017 |
-| Mopidy     | 2016 |
-| Neo4j  | 2016 |
-| NeoVim     | 2017 |
-| Netty  | 2017 |
-| Node   | 2017 |
-| OpenCV     | 2016 |
-| OpenRA     | 2015 |
-| OpenTripPlanner    | 2016 |
-| Play Framework     | 2015 |
-| Processing     | 2017 |
-| RocketChat  | 2018 |
-| Ruby on Rails  | 2016 |
-| Scikit Learn   | 2017 |
-| Scrapy     | 2017 |
-| Sonic PI   | 2016 |
-| Strapi | 2018 |
-| SyncAny    | 2015 |
-| Syncthing  | 2017 |
-| SwaggerUI | 2018 |
-| Telegram Web   | 2017 |
-| TensorFlow     | 2016 |
-| TensorBoard | 2018 |
-| Toyplot | 2018 |
-| Terasology     | 2016 |
-| Vagrant    | 2015 |
-| VS Code    | 2017 |
-| Wildfly    | 2016 |
-| Yarn   | 2017 |
-| Youtube-DL     | 2016 |
-| akka          | 2018 |
-| angular       | 2018 |
-| contributions | 2018 |
-| desosa-covers | 2018 |
-| docker        | 2018 |
-| eden          | 2018 |
-| elasticsearch | 2018 |
-| electron      | 2018 |
-| godot         | 2018 |
-| images        | 2018 |
-| jenkins       | 2018 |
-| kubernetes    | 2018 |
-| lighthouse    | 2018 |
-| loopback      | 2018 |
-| mattermost    | 2018 |
-| mbedos        | 2018 |
-| osu           | 2018 |
-| phaser        | 2018 |
-| react         | 2018 |
-| spark         | 2018 |
-| threejs       | 2018 |
-| typescript    | 2018 |
-| vuejs         | 2018 |
-| xmage | 2018 |
+| Project                                                                    | Year |
+| -------------------------------------------------------------------------- | ---- |
+| [akka](https://github.com/akka/akka)                                       | 2018 |
+| [angular](https://github.com/angular/angular)                              | 2018 |
+| [AngularDart](https://github.com/dart-lang/angular)                        | 2015 |
+| [Arduino](https://github.com/arduino/Arduino)                              | 2017 |
+| [Atom](https://github.com/atom/atom)                                       | 2016 |
+| [BigBlueButton](https://github.com/bigbluebutton/bigbluebutton)            | 2016 |
+| [Bootstrap](https://github.com/twbs/bootstrap)                             | 2016 |
+| [Cartographer](https://github.com/googlecartographer/cartographer)         | 2018 |
+| [CKAN](https://github.com/ckan/ckan)                                       | 2016 |
+| [CodeCombat](https://github.com/codecombat/codecombat)                     | 2016 |
+| contributions                                                              | 2018 |
+| [D3.js](https://github.com/d3/d3)                                          | 2016 |
+| [Diaspora](https://github.com/diaspora/diaspora)                           | 2018 |
+| [docker](https://github.com/docker/engine)                                 | 2015 |
+| [Docker](https://github.com/docker/toolbox)                                | 2018 |
+| [eden](https://github.com/sahana/eden)                                     | 2018 |
+| [elasticsearch](https://github.com/elastic/elasticsearch)                  | 2018 |
+| [electron](https://github.com/electron/electron)                           | 2018 |
+| [Ember.js](https://github.com/emberjs/ember.js)                            | 2016 |
+| [Gitlab](https://github.com/gitlabhq/gitlabhq)                             | 2016 |
+| [godot](https://github.com/godotengine/godot)                              | 2018 |
+| [Gradle](https://github.com/gradle/gradle)                                 | 2017 |
+| [Guava](https://github.com/google/guava)                                   | 2016 |
+| [Habitica](https://github.com/HabitRPG/habitica)                           | 2016 |
+| [Homebrew](https://github.com/Homebrew/brew)                               | 2018 |
+| images                                                                     | 2018 |
+| [JabRef](https://github.com/JabRef/jabref)                                 | 2017 |
+| [Jekyll](https://github.com/jekyll/jekyll)                                 | 2015 |
+| [jenkins](https://github.com/jenkinsci/jenkins)                            | 2018 |
+| [Joomla](https://github.com/joomla/joomla-cms)                             | 2015 |
+| [Junit5](https://github.com/junit-team/junit5)                             | 2017 |
+| [Jupyter Notebook](https://github.com/jupyter/notebook)                    | 2017 |
+| [Kafka](https://github.com/apache/kafka)                                   | 2017 |
+| [Karma](https://github.com/karma-runner/karma)                             | 2016 |
+| [Keras](https://github.com/keras-team/keras)                               | 2018 |
+| [Kibana](https://github.com/elastic/kibana)                                | 2017 |
+| [Kodi (xbmc)](https://github.com/xbmc/xbmc)                                | 2015 |
+| [kubernetes](https://github.com/kubernetes/kubernetes)                     | 2018 |
+| [lighthouse](https://github.com/GoogleChrome/lighthouse)                   | 2018 |
+| [loopback](https://github.com/strongloop/loopback)                         | 2018 |
+| [Magento](https://github.com/magento/magento2)                             | 2017 |
+| [Mapbox GL](https://github.com/mapbox/mapbox-gl-js)                        | 2017 |
+| [MatplotLib](https://github.com/matplotlib/matplotlib)                     | 2017 |
+| [mattermost](https://github.com/mattermost/mattermost-server)              | 2018 |
+| [mbedos](https://github.com/ARMmbed/mbed-os/)                              | 2018 |
+| [Mockito](https://github.com/mockito/mockito)                              | 2017 |
+| [Mopidy](https://github.com/mopidy/mopidy)                                 | 2016 |
+| [Neo4j](https://github.com/neo4j/neo4j)                                    | 2016 |
+| [NeoVim](https://github.com/neovim/neovim)                                 | 2017 |
+| [Netty](https://github.com/netty/netty)                                    | 2017 |
+| [Node](https://github.com/nodejs/node)                                     | 2017 |
+| [OpenCV](https://github.com/opencv/opencv)                                 | 2016 |
+| [OpenRA](https://github.com/OpenRA/OpenRA)                                 | 2015 |
+| [OpenTripPlanner](https://github.com/opentripplanner/OpenTripPlanner)      | 2016 |
+| [osu](https://github.com/ppy/osu)                                          | 2018 |
+| [phaser](https://github.com/photonstorm/phaser)                            | 2018 |
+| [Play Framework](https://github.com/playframework/playframework)           | 2015 |
+| [Processing](https://github.com/processing/processing)                     | 2017 |
+| [react](https://github.com/facebook/react)                                 | 2018 |
+| [RocketChat](https://github.com/RocketChat/hubot-rocketchat)               | 2018 |
+| [Ruby on Rails](https://github.com/rails/rails)                            | 2016 |
+| [Scikit Learn](https://github.com/scikit-learn/scikit-learn)               | 2017 |
+| [Scrapy](https://github.com/scrapy/scrapy)                                 | 2017 |
+| [Sonic PI](https://github.com/samaaron/sonic-pi)                           | 2016 |
+| [spark](https://github.com/apache/spark)                                   | 2018 |
+| [Strapi](https://github.com/strapi/strapi)                                 | 2018 |
+| [SwaggerUI](https://github.com/swagger-api/swagger-ui)                     | 2018 |
+| [SyncAny](https://github.com/syncany/syncany)                              | 2015 |
+| [Syncthing](https://github.com/syncthing/syncthing)                        | 2017 |
+| [Telegram Web](https://github.com/zhukov/webogram)                         | 2017 |
+| [TensorBoard](https://github.com/tensorflow/tensorboard)                   | 2018 |
+| [TensorFlow](https://github.com/tensorflow/tensorflow)                     | 2016 |
+| [Terasology](https://github.com/MovingBlocks/Terasology)                   | 2016 |
+| [threejs](https://github.com/mrdoob/three.js/)                             | 2018 |
+| [Toyplot](https://github.com/sandialabs/toyplot)                           | 2018 |
+| [typescript](https://github.com/Microsoft/TypeScript)                      | 2018 |
+| [Vagrant](https://github.com/hashicorp/vagrant)                            | 2015 |
+| [VS Code](https://github.com/Microsoft/vscode)                             | 2017 |
+| [vuejs](https://github.com/vuejs/vue)                                      | 2018 |
+| [Wildfly](https://github.com/wildfly/wildfly)                              | 2016 |
+| [xmage](https://github.com/magefree/mage)                                  | 2018 |
+| [Yarn](https://github.com/yarnpkg/yarn)                                    | 2017 |
+| [Youtube-DL](https://github.com/rg3/youtube-dl)                            | 2016 |

--- a/banned.md
+++ b/banned.md
@@ -83,3 +83,34 @@
 | [xmage](https://github.com/magefree/mage)                                  | 2018 |
 | [Yarn](https://github.com/yarnpkg/yarn)                                    | 2017 |
 | [Youtube-DL](https://github.com/rg3/youtube-dl)                            | 2016 |
+
+Disclaimer: These links were auto-generated using the GitHub search API. As such, some of them may not point to the correct project. The script used to perform a search is below, use (modify) it to update this list in the future.
+
+```bash
+#!/bin/bash
+
+GITHUB_AUTH_TOKEN=<Your_GitHub_Auth_Token_Here>
+> banned-urls.txt; # Clear or create the output file.
+
+# You'd probably prefer to pipe in a list here. 
+echo -e "typescript\nVS Code" |
+while IFS= read -r line
+    do
+        RESPONSE=$(curl                                                     \
+        --header "Authorization: bearer $GITHUB_AUTH_TOKEN"                 \
+        --data                                                              \
+        "{                                                                  \
+            \"query\": \"query {                                            \
+                search(query: \\\"$line\\\", type: REPOSITORY, first: 1) {  \
+                    edges { node {                                          \
+                        ... on Repository { url }                           \
+                } } } }\"                                                   \
+        }"                                                                  \
+        https://api.github.com/graphql);
+        
+        echo $RESPONSE                                                      \
+            | grep -o 'https://[^"]*'                                       \
+            | awk -v line="$line" '{print "["line"]("$1")"}'                \
+            >> banned-urls.txt;
+done
+```

--- a/banned.md
+++ b/banned.md
@@ -94,14 +94,14 @@ GITHUB_AUTH_TOKEN=<Your_GitHub_Auth_Token_Here>
 
 # You'd probably prefer to pipe in a list here. 
 echo -e "typescript\nVS Code" |
-while IFS= read -r line
+while IFS= read -r name
     do
         RESPONSE=$(curl                                                     \
         --header "Authorization: bearer $GITHUB_AUTH_TOKEN"                 \
         --data                                                              \
         "{                                                                  \
             \"query\": \"query {                                            \
-                search(query: \\\"$line\\\", type: REPOSITORY, first: 1) {  \
+                search(query: \\\"$name\\\", type: REPOSITORY, first: 1) {  \
                     edges { node {                                          \
                         ... on Repository { url }                           \
                 } } } }\"                                                   \
@@ -110,7 +110,7 @@ while IFS= read -r line
         
         echo $RESPONSE                                                      \
             | grep -o 'https://[^"]*'                                       \
-            | awk -v line="$line" '{print "["line"]("$1")"}'                \
+            | awk -v name="$name" '{print "["name"]("$1")"}'                \
             >> banned-urls.txt;
 done
 ```


### PR DESCRIPTION
Just ran the project names from `banned.md` through `curl` against [api.github.com/graphql](https://developer.github.com/v4/explorer/) and took the first result - then cleaned the 5 or so that didn't get the right repo from the search by hand.

```gql
query firstRepoByName($projectName: String!) {
 search(query: $projectName, type: REPOSITORY, first: 1) {
  edges { node {
    ... on Repository { url }
} } } }
```

Also re-alphabetized the table.